### PR TITLE
v1.4

### DIFF
--- a/Classes/MonomeGrid.sc
+++ b/Classes/MonomeGrid.sc
@@ -10,49 +10,48 @@ raja das, ezra buchla, dan derks
 
 MonomeGrid {
 
-	classvar seroscnet, <>discovery, <>rows, <>columns, <>portlst, quadDirty, ledQuads, redrawTimer;
-	var <>prefix, <>rot, <>fps, <>dvcnum, oscout;
+	classvar seroscnet, discovery,
+	prefixHandler,
+	add, addCallback, addCallbackComplete,
+	remove, removeCallback, removeCallbackComplete,
+	rows, columns,
+	portlst, prefixes, connectedDevices,
+	quadDirty, ledQuads, redrawTimers;
+
+	var prefixID, rot, fpsVal, dvcID, keyFunc, oscout; // instance variables
 
 	*initClass {
 
 		var sz, rw, cl;
 
+		addCallback = nil;
+		removeCallback = nil;
 		portlst = List.new(0);
+		connectedDevices = List.new(0);
+		addCallbackComplete = List.new(0);
+		removeCallbackComplete = List.new(0);
 		rows = List.new(0);
 		columns = List.new(0);
+		prefixes = List.new(0);
 		seroscnet = NetAddr.new("localhost", 12002);
 		seroscnet.sendMsg("/serialosc/list", "127.0.0.1", NetAddr.localAddr.port);
+		seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
 
 		quadDirty = Dictionary.new;
 		ledQuads = Dictionary.new;
-		redrawTimer = Dictionary.new;
+		redrawTimers = Dictionary.new;
 
-		StartUp.add {
+		this.buildOSCResponders;
 
-			discovery = OSCdef.newMatching(\monomediscover,
-				{|msg, time, addr, recvPort|
-
-					sz = msg[2].asString.replace("monome","").replace("40h",64).asInteger;
-					rw = case
-					{sz == 64} {8}
-					{sz == 128}{8}
-					{sz == 256}{16}
-					{sz == 512}{16};
-					cl = case
-					{sz == 64} {8}
-					{sz == 128}{16}
-					{sz == 256}{16}
-					{sz == 512}{32};
-					rows.add(rw);
-					columns.add(cl);
-					portlst.add(msg[3]);
-					("MonomeGrid device connected on port:"++msg[3]).postln;
-					("MonomeGrid serial: "++msg[1]).postln;
-					("MonomeGrid model: "++msg[2]).postln;
-
-			}, '/serialosc/device', seroscnet);
-
-		}
+		ServerQuit.add({
+			seroscnet.disconnect;
+			add.free;
+			discovery.free;
+			remove.free;
+			redrawTimers.do({arg dvc;
+				redrawTimers[dvc].stop;
+			});
+		},\default);
 
 	}
 
@@ -75,99 +74,339 @@ MonomeGrid {
 		^ super.new.init(prefix, rotation, fps);
 	}
 
+	*buildOSCResponders {
+		var sz, rw, cl;
+
+		add = OSCdef.newMatching(\monomeadd,
+			{|msg, time, addr, recvPort|
+
+				var portIDX;
+
+				sz = msg[2].asString.replace("monome","").replace("40h",64).asInteger;
+
+				if( sz != 0,{ // if not an arc
+					rw = case
+					{sz == 64} {8}
+					{sz == 128}{8}
+					{sz == 256}{16}
+					{sz == 512}{16};
+					cl = case
+					{sz == 64} {8}
+					{sz == 128}{16}
+					{sz == 256}{16}
+					{sz == 512}{32};
+
+					if( portlst.includes(msg[3]) == false, {
+						rows.add(rw);
+						columns.add(cl);
+						portlst.add(msg[3]);
+						prefixes.add("/monome");
+						connectedDevices.add(msg[1]);
+						addCallbackComplete.add(false);
+						removeCallbackComplete.add(false);
+					});
+					portIDX = portlst.detectIndex({arg item, i; item == msg[3]});
+					if( addCallbackComplete[portIDX] == false,{
+						("MonomeGrid device added to port: "++msg[3]).postln;
+						("MonomeGrid serial: "++msg[1]).postln;
+						("MonomeGrid model: "++msg[2]).postln;
+						addCallback.value(msg[1],msg[3],prefixes[portIDX]);
+						addCallbackComplete[portIDX] = true;
+						removeCallbackComplete[portIDX] = false;
+					});
+				}
+				);
+
+				seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+
+		}, '/serialosc/add', seroscnet);
+
+		remove = OSCdef.newMatching(\monomeremove,
+			{|msg, time, addr, recvPort|
+				var portIDX;
+
+				sz = msg[2].asString.replace("monome","").replace("40h",64).asInteger;
+
+				if( sz != 0,{ // if not an arc
+					rw = case
+					{sz == 64} {8}
+					{sz == 128}{8}
+					{sz == 256}{16}
+					{sz == 512}{16};
+					cl = case
+					{sz == 64} {8}
+					{sz == 128}{16}
+					{sz == 256}{16}
+					{sz == 512}{32};
+
+					portIDX = portlst.detectIndex({arg item, i; item == msg[3]});
+					if( portIDX != nil, {
+						if( removeCallbackComplete[portIDX] == false, {
+							removeCallback.value(msg[2],msg[1],msg[3],prefixes[portIDX]);
+							("MonomeGrid device removed from port: "++msg[3]).postln;
+							("MonomeGrid serial: "++msg[1]).postln;
+							("MonomeGrid model: "++msg[2]).postln;
+							addCallbackComplete[portIDX] = false;
+							removeCallbackComplete[portIDX] = true;
+						});
+					});
+				});
+
+				seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+
+		}, '/serialosc/remove', seroscnet);
+
+		discovery = OSCdef.newMatching(\monomediscover,
+			{|msg, time, addr, recvPort|
+
+				var portIDX;
+
+				sz = msg[2].asString.replace("monome","").replace("40h",64).asInteger;
+
+				if( sz != 0,{ // if not an arc
+					rw = case
+					{sz == 64} {8}
+					{sz == 128}{8}
+					{sz == 256}{16}
+					{sz == 512}{16};
+					cl = case
+					{sz == 64} {8}
+					{sz == 128}{16}
+					{sz == 256}{16}
+					{sz == 512}{32};
+
+					if( portlst.includes(msg[3]) == false, {
+						rows.add(rw);
+						columns.add(cl);
+						portlst.add(msg[3]);
+						connectedDevices.add(msg[1]);
+						prefixes.add("/monome");
+						addCallbackComplete.add(false);
+						removeCallbackComplete.add(false);
+						("MonomeGrid device connected to port: "++msg[3]).postln;
+						("MonomeGrid serial: "++msg[1]).postln;
+						("MonomeGrid model: "++msg[2]).postln;
+						portIDX = portlst.detectIndex({arg item, i; item == msg[3]});
+						addCallback.value(msg[1],msg[3],prefixes[portIDX]);
+					},{
+						// ("grid already registered!!!").postln;
+					});
+				});
+
+				seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+
+		}, '/serialosc/device', seroscnet);
+
+	}
+
+	*refreshConnections {
+		portlst.clear; connectedDevices.clear; prefixes.clear; rows.clear; columns.clear;
+		seroscnet.sendMsg("/serialosc/list", "127.0.0.1", NetAddr.localAddr.port);
+	}
+
+	*getConnectedDevices {
+		^connectedDevices;
+	}
+
+	*getPortList {
+		^portlst;
+	}
+
+	*getPrefixes {
+		^prefixes;
+	}
+
+	*setAddCallback { arg func;
+		addCallback = nil;
+		addCallback = func;
+	}
+
+	*setRemoveCallback { arg func;
+		removeCallback = nil;
+		removeCallback = func;
+	}
+
 	init { arg prefix_, rot_, fps_;
-		prefix = prefix_;
+		prefixID = prefix_;
 		rot = rot_;
-		fps = fps_;
+		fpsVal = fps_;
+	}
+
+	connectToPort { arg port;
+		if( portlst.includes(port),{
+			var idx = portlst.detectIndex({arg item, i; item == port});
+			this.connect(idx);
+		},{
+			("no monome grid connected to specified port").warn;
+		});
+	}
+
+	connectToSerial { arg serial;
+		if( connectedDevices.includes(serial.asSymbol),{
+			var idx = connectedDevices.detectIndex({arg item, i; item == serial});
+			this.connect(idx);
+		},{
+			("no monome grid connected with specified serial").warn;
+		});
 	}
 
 	connect { arg devicenum;
 		if( devicenum == nil, {devicenum = 0});
 		if( portlst[devicenum].value != nil, {
-			dvcnum = devicenum;
-			oscout = NetAddr.new("localhost", portlst[devicenum].value);
-			Post << "MonomeGrid: using device on port#" << portlst[devicenum].value << Char.nl;
 
-			oscout.sendMsg(prefix++"/grid/led/all", 0);
+			var prefixDiscover;
+
+			MonomeGrid.buildOSCResponders;
+
+			dvcID = devicenum;
+			oscout = NetAddr.new("localhost", portlst[devicenum].value);
+			Post << "MonomeGrid: using device on port #" << portlst[devicenum].value << Char.nl;
+
+			oscout.sendMsg(prefixID++"/grid/led/all", 0);
+
+			prefixDiscover.free;
+			prefixDiscover = OSCdef.newMatching(\monomeprefix,
+				{|msg, time, addr, recvPort|
+					// msg[1].postln;
+					prefixes[devicenum] = prefixID;
+			}, '/sys/prefix', oscout);
 
 			oscout.sendMsg("/sys/port", NetAddr.localAddr.port);
-			oscout.sendMsg("/sys/prefix", prefix);
+			oscout.sendMsg("/sys/prefix", prefixID);
 			oscout.sendMsg("/sys/rotation", rot);
+			oscout.sendMsg("/sys/info");
 
 			// collect individual LED messages into a 'map':
-			quadDirty[dvcnum] = Array.fill(8,{0});
-			ledQuads[dvcnum] = Array.fill(8,{Array.fill(64,{0})});
+			quadDirty[dvcID] = Array.fill(8,{0});
+			ledQuads[dvcID] = Array.fill(8,{Array.fill(64,{0})});
 
-			redrawTimer[dvcnum] = Routine({
-				var interval = 1/fps,
+			redrawTimers[dvcID].stop;
+
+			redrawTimers[dvcID] = Routine({
+				var interval = 1/fpsVal,
 				offsets = [
-					[0,0],[8,0],[0,8],[8,8],[16,0][24,0],[16,8],[24,8]
+					[0,0],[8,0],[0,8],[8,8]
 				],
 				max = case
-				{(rows[dvcnum] == 8) && (columns[dvcnum] == 8)}{0}
-				{(rows[dvcnum] == 8) && (columns[dvcnum] == 16)}{1}
-				{(rows[dvcnum] == 16) && (columns[dvcnum] == 16)}{3}
-				{(rows[dvcnum] == 16) && (columns[dvcnum] == 32)}{7};
+				{(rows[dvcID] == 8) && (columns[dvcID] == 8)}{0}
+				{(rows[dvcID] == 8) && (columns[dvcID] == 16)}{1}
+				{(rows[dvcID] == 16) && (columns[dvcID] == 16)}{3};
+
 				loop {
-					for (0, max, {
-						arg i;
-						if(quadDirty[dvcnum][i] != 0,
-							{
-								oscout.sendMsg(
-									prefix++"/grid/led/level/map",
-									offsets[i][0],
-									offsets[i][1],
-									*ledQuads[dvcnum][i]
-								);
-								quadDirty[dvcnum][i] = 0;
-							}
-						);
-						interval.yield;
+					if(portlst[devicenum].value != nil,{
+						for (0, max, {
+							arg i;
+							if(quadDirty[dvcID][i] != 0,
+								{
+									oscout.sendMsg(
+										prefixID++"/grid/led/level/map",
+										offsets[i][0],
+										offsets[i][1],
+										*ledQuads[dvcID][i]
+									);
+									quadDirty[dvcID][i] = 0;
+								}
+							);
+						});
 					});
+
+					interval.yield;
 				}
+
 			});
 
-			redrawTimer[dvcnum].play();
+			redrawTimers[dvcID].play();
+			addCallbackComplete[dvcID] = false;
+			addCallback.value(connectedDevices[dvcID], portlst[dvcID], prefixes[dvcID]);
+			seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
 		},{
-			'!! no monome grid detected !!'.postln;
-			'  connect a grid and execute MonomeGrid.initClass() ,'.postln;
-			'  or Recompile Class Library'.postln;
+			("no monome grid detected at device slot " ++ devicenum).warn;
 		});
 	}
 
 	usePort { arg portnum;
-		dvcnum = portlst.indexOf(portnum);
+		dvcID = portlst.indexOf(portnum);
 		oscout = NetAddr.new("localhost", portnum);
-		Post << "MonomeGrid: using device #" << dvcnum << Char.nl;
+		Post << "MonomeGrid: using device # " << dvcID << Char.nl;
 
 		oscout.sendMsg("/sys/port", NetAddr.localAddr.port);
-		oscout.sendMsg("/sys/prefix", prefix);
+		oscout.sendMsg("/sys/prefix", prefixID);
 		oscout.sendMsg("/sys/rotation", rot);
 	}
 
 	port {
-		^portlst[dvcnum];
+		if( dvcID != nil, {
+			^portlst[dvcID];
+		},{
+			^nil;
+		});
 	}
 
 	rows {
-		^rows[dvcnum];
+		if( dvcID != nil, {
+			^rows[dvcID];
+		},{
+			^nil;
+		});
 	}
 
 	cols {
-		^columns[dvcnum];
+		if( dvcID != nil, {
+			^columns[dvcID];
+		},{
+			^nil;
+		});
 	}
 
+	serial {
+		if( dvcID != nil, {
+			^connectedDevices[dvcID];
+		},{
+			^nil;
+		});
+	}
+
+	prefix {
+		if( dvcID != nil, {
+			^prefixes[dvcID];
+		},{
+			^nil;
+		});
+	}
+
+	rotation {
+		if( dvcID != nil, {
+			^rot
+		},{
+			^nil;
+		});
+	}
+
+	fps {
+		if( dvcID != nil, {
+			^fpsVal
+		},{
+			^nil;
+		});
+	}
+
+	dvcnum {
+		^dvcID;
+	}
+
+
 	key { arg func;
-		OSCFunc.newMatching(
+		keyFunc = OSCdef.newMatching(
+			("keyFunc_" ++ dvcID).asSymbol,
 			{ arg message, time, addr, recvPort;
 				var x = message[1], y = message[2], z = message[3];
-				if( dvcnum != nil,{
+				if( dvcID != nil,{
 					if( this.port.value() == addr.port, {
 						func.value(x,y,z);
 					});
 				});
 			},
-			prefix++"/grid/key"
+			prefixID++"/grid/key"
 		);
 	}
 
@@ -177,88 +416,79 @@ MonomeGrid {
 		// 64: quad01 (top left)
 		{(x < 8) && (y < 8)} {
 			offset = (8*y)+x;
-			ledQuads[dvcnum][0][offset] = val;
-			quadDirty[dvcnum][0] = 1;
+			ledQuads[dvcID][0][offset] = val;
+			quadDirty[dvcID][0] = 1;
 		}
 		// 128: quad 1 (top right)
 		{(x > 7) && (x < 16) && (y < 8)} {
 			offset = (8*y)+(x-8);
-			ledQuads[dvcnum][1][offset] = val;
-			quadDirty[dvcnum][1] = 1;
+			ledQuads[dvcID][1][offset] = val;
+			quadDirty[dvcID][1] = 1;
 		}
 		// 256: quad 2 (bottom left)
 		{(x < 8) && (y > 7) && (y < 16)} {
 			offset = (8*(y-8))+x;
-			ledQuads[dvcnum][2][offset] = val;
-			quadDirty[dvcnum][2] = 1;
+			ledQuads[dvcID][2][offset] = val;
+			quadDirty[dvcID][2] = 1;
 		}
 		// 256: quad 3 (bottom right)
 		{(x > 7) && (x < 16) && (y > 7) && (y < 16)} {
 			offset = (8*(y-8))+(x-8);
-			ledQuads[dvcnum][3][offset] = val;
-			quadDirty[dvcnum][3] = 1;
+			ledQuads[dvcID][3][offset] = val;
+			quadDirty[dvcID][3] = 1;
 		}
-		// 512: quad 4 (top mid-right)
+		/*// 512: quad 4 (top mid-right)
 		{(x > 15) && (x < 24) && (y < 8)} {
 			offset = (8*y)+(x-16);
-			ledQuads[dvcnum][4][offset] = val;
-			quadDirty[dvcnum][4] = 1;
+			ledQuads[dvcID][4][offset] = val;
+			quadDirty[dvcID][4] = 1;
 		}
 		// 512: quad 5 (top far right)
 		{(x > 23) && (x < 32) && (y < 8)} {
 			offset = (8*y)+(x-24);
-			ledQuads[dvcnum][5][offset] = val;
-			quadDirty[dvcnum][5] = 1;
+			ledQuads[dvcID][5][offset] = val;
+			quadDirty[dvcID][5] = 1;
 		}
 		// 512: quad 6 (bottom mid-right)
 		{(x > 15) && (x < 24) && (y > 7) && (y < 16)} {
 			offset = (8*(y-8))+(x-16);
-			ledQuads[dvcnum][6][offset] = val;
-			quadDirty[dvcnum][6] = 1;
+			ledQuads[dvcID][6][offset] = val;
+			quadDirty[dvcID][6] = 1;
 		}
 		// 512: quad 7 (bottom far right)
 		{(x > 23) && (x < 32) && (y > 7) && (y < 16)} {
 			offset = (8*(y-8))+(x-24);
-			ledQuads[dvcnum][7][offset] = val;
-			quadDirty[dvcnum][7] = 1;
-		}
+			ledQuads[dvcID][7][offset] = val;
+			quadDirty[dvcID][7] = 1;
+		}*/
 	}
 
 	all { arg val;
-		oscout.sendMsg(prefix++"/grid/led/level/all", val);
+		oscout.sendMsg(prefixID++"/grid/led/level/all", val);
 	}
 
 	// See here: http://monome.org/docs/tech:osc
 	// if you need further explanation of the LED methods below
 	ledset	{ arg x, y, state;
 		if ((state == 0) or: (state == 1)) {
-			oscout.sendMsg(prefix++"/grid/led/set", x, y, state);
+			oscout.sendMsg(prefixID++"/grid/led/set", x, y, state);
 		} {
 			"invalid argument (state must be 0 or 1).".warn;
 		};
 	}
 
 	intensity	{ arg val;
-		oscout.sendMsg(prefix++"/grid/led/intensity", val);
+		oscout.sendMsg(prefixID++"/grid/led/intensity", val);
 	}
 
 	tilt_enable { arg device, state;
-		oscout.sendMsg(prefix++"/tilt/set", device, state);
-	}
-
-	deviceList {
-		portlst.clear; rows.clear; columns.clear;
-		seroscnet.sendMsg("/serialosc/list", "127.0.0.1", NetAddr.localAddr.port);
+		oscout.sendMsg(prefixID++"/tilt/set", device, state);
 	}
 
 	cleanup {
 		this.all(0);
-		discovery.free;
-		redrawTimer.do({arg dvc;
-			redrawTimer[dvc].stop;
-		});
+		keyFunc.free;
 		oscout.disconnect;
-		seroscnet.disconnect;
 	}
 
 }

--- a/HelpSource/Classes/MonomeGrid.schelp
+++ b/HelpSource/Classes/MonomeGrid.schelp
@@ -41,7 +41,54 @@ rate of maximum grid redraw in frames per second
 
 defaults to 60 if nil
 
+METHOD:: setAddCallback
+assign a callback function whenever a new grid is added / physically connected
+
+ARGUMENT:: func
+
+code::
+// make sure to clear any running grid code before executing
+(
+MonomeGrid.setAddCallback({
+	arg serial, port, prefix;
+	["grid was added",serial,port,prefix].postln;
+});
+)
+::
+
+METHOD:: setRemoveCallback
+assign a callback function whenever an added grid is removed / physically disconnected
+
+ARGUMENT:: func
+
+code::
+// make sure to clear any running grid code before executing
+(
+MonomeGrid.setRemoveCallback({
+	arg serial, port, prefix;
+	["grid was remnoved",serial,port,prefix].postln;
+});
+)
+::
+
+METHOD:: getConnectedDevices
+returns the serial numbers of each device that's been connected since the Server started (or last refreshConnections)
+
+METHOD:: getPortList
+returns the OSC ports of each device that's been connected since the Server started (or last refreshConnections)
+
+METHOD:: getPrefixes
+returns the assigned prefixes of each device that's been connected since the Server started (or last refreshConnections)
+
+METHOD:: refreshConnections
+sends message to serialosc to refresh SuperCollider's list of currently-connected devices
+
+
+PRIVATE:: buildOSCResponders
+
 PRIVATE:: portlst
+
+PRIVATE:: prefixes
 
 PRIVATE:: rows
 
@@ -60,6 +107,18 @@ ARGUMENT:: devicenum
 device list index, begins at 0
 
 if not provided, will default to 0
+
+METHOD:: connectToPort
+choose which device to connect via OSC port
+
+ARGUMENT:: port
+OSC port identifier
+
+METHOD:: connectToSerial
+choose which device to connect via serial string
+
+ARGUMENT:: serial
+serial identifier
 
 METHOD:: key
 assign a function to interpret key presses
@@ -178,17 +237,20 @@ RETURNS:: device prefix
 METHOD:: dvcnum
 RETURNS:: index of device in device list (0-indexed)
 
-METHOD:: rot
+METHOD:: serial
+RETURNS:: the device's serial number
+
+METHOD:: port
+RETURNS:: OSC port the device is currently communicating on
+
+METHOD:: rotation
 RETURNS:: rotation of device (cable orientation): 0, 90, 180, 270
+
+METHOD:: fps
+RETURNS:: the device's redraw rate (frames per second)
 
 METHOD:: rows
 returns:: number of rows a grid device has (1-indexed)
 
 METHOD:: cols
 RETURNS:: number of columns a grid device has (1-indexed)
-
-METHOD:: port
-RETURNS:: port the device is currently communicating on
-
-METHOD:: deviceList
-sends message to serialosc to report what devices are connected


### PR DESCRIPTION
## NEW

### see updated help file in SuperCollider and the accompanying [grid study](https://monome.org/docs/grid/studies/sc/) for more details

### Class
- alerts whenever a grid is physically connected / disconnected
- grid add + remove callbacks: assign a callback function whenever a new grid is physically connected / disconnected
- getters for serials, ports, and prefixes for devices connected since the Server last booted
- method to refresh SuperCollider's understanding of the currently-connected devices
- `new` now accepts arguments for grid prefix and frames-per-second redraw rate

### Instance
- connect to grid via OSC port or serial number
- accessors for prefix, device number, serial, OSC port, rotation, frames-per-second redraw rate, rows, columns

## FIXED

### Class
- redraw loop has `yield` _outside_ of the quadrant iterator (previously, was inside 😅 )
- library is _much_ more forgiving of grid connect/disconnect, no longer requiring all devices to be present at Server boot
- OSC responders are restarted with each sketch if sclang is stopped (previously required a Server reboot)
- Server quit better cleans Class OSCdefs