### PR TITLE
discover connected device's size with '/sys' messages

### DIFF
--- a/Classes/MonomeGrid.sc
+++ b/Classes/MonomeGrid.sc
@@ -1,5 +1,5 @@
 /*
-
+v.1.6
 for information about monome devices:
 monome.org
 
@@ -77,37 +77,44 @@ MonomeGrid {
 		add = OSCdef.newMatching(\monomeadd,
 			{|msg, time, addr, recvPort|
 
-				var portIDX, sizeDiscover;
+				var portIDX, sizeDiscover, rw, cl, portID, serial, model;
 
-				if( (msg[2].asString).contains("arc"), { /* no arc support yet */ }, { /* grid support only: */
-					if( portlst.includes(msg[3]) == false, {
-						portlst.add(msg[3]);
-						prefixes.add("/monome");
-						connectedDevices.add(msg[1]);
-						addCallbackComplete.add(false);
-						removeCallbackComplete.add(false);
-						NetAddr("localhost", msg[3].value).sendMsg("/sys/info", "localhost",NetAddr.localAddr.port);
-						sizeDiscover = OSCdef.newMatching(\sizeDiscovery,
-							{|msg, time, addr, recvPort|
+				serial = msg[1];
+				model = msg[2];
+				portID = msg[3];
+
+				NetAddr("localhost", msg[3].value).sendMsg("/sys/info", "localhost",NetAddr.localAddr.port);
+				sizeDiscover = OSCdef.newMatching(\sizeDiscovery,
+					{|msg, time, addr, recvPort|
+						cl = msg[1];
+						rw = msg[2];
+						if( (cl * rw) > 0, { /* grid support only: */
+							if( portlst.includes(portID) == false, {
 								columns.add(msg[1]);
 								rows.add(msg[2]);
-								sizeDiscover.free;
-							}, '/sys/size', NetAddr("localhost", msg[3].value)
+								portlst.add(portID);
+								prefixes.add("/monome");
+								connectedDevices.add(serial);
+								addCallbackComplete.add(false);
+								removeCallbackComplete.add(false);
+							});
+							portIDX = portlst.detectIndex({arg item, i; item == portID});
+							if( addCallbackComplete[portIDX] == false,{
+								("MonomeGrid device added to port: "++portID).postln;
+								("MonomeGrid serial: "++serial).postln;
+								("MonomeGrid model: "++model).postln;
+								addCallback.value(serial,portID,prefixes[portIDX]);
+								addCallbackComplete[portIDX] = true;
+								removeCallbackComplete[portIDX] = false;
+							});
+						},{
+							"no monome arc support yet".postln;
+						};
+						seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+						sizeDiscover.free;
 						);
-					});
-					portIDX = portlst.detectIndex({arg item, i; item == msg[3]});
-					if( addCallbackComplete[portIDX] == false,{
-						("MonomeGrid device added to port: "++msg[3]).postln;
-						("MonomeGrid serial: "++msg[1]).postln;
-						("MonomeGrid model: "++msg[2]).postln;
-						addCallback.value(msg[1],msg[3],prefixes[portIDX]);
-						addCallbackComplete[portIDX] = true;
-						removeCallbackComplete[portIDX] = false;
-					});
-				}
+					}, '/sys/size', NetAddr("localhost", msg[3].value)
 				);
-
-				seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
 
 		}, '/serialosc/add', seroscnet);
 
@@ -115,18 +122,15 @@ MonomeGrid {
 			{|msg, time, addr, recvPort|
 				var portIDX;
 
-				if( (msg[2].asString).contains("arc"), { /* no arc support yet */ }, { /* grid support only: */
-
-					portIDX = portlst.detectIndex({arg item, i; item == msg[3]});
-					if( portIDX.notNil, {
-						if( removeCallbackComplete[portIDX] == false, {
-							removeCallback.value(msg[2],msg[1],msg[3],prefixes[portIDX]);
-							("MonomeGrid device removed from port: "++msg[3]).postln;
-							("MonomeGrid serial: "++msg[1]).postln;
-							("MonomeGrid model: "++msg[2]).postln;
-							addCallbackComplete[portIDX] = false;
-							removeCallbackComplete[portIDX] = true;
-						});
+				portIDX = portlst.detectIndex({arg item, i; item == msg[3]});
+				if( portIDX.notNil, {
+					if( removeCallbackComplete[portIDX] == false, {
+						removeCallback.value(msg[2],msg[1],msg[3],prefixes[portIDX]);
+						("MonomeGrid device removed from port: "++msg[3]).postln;
+						("MonomeGrid serial: "++msg[1]).postln;
+						("MonomeGrid model: "++msg[2]).postln;
+						addCallbackComplete[portIDX] = false;
+						removeCallbackComplete[portIDX] = true;
 					});
 				});
 
@@ -137,35 +141,42 @@ MonomeGrid {
 		discovery = OSCdef.newMatching(\monomediscover,
 			{|msg, time, addr, recvPort|
 
-				var portIDX, sizeDiscover;
+				var portIDX, sizeDiscover, rw, cl, portID, serial, model;
 
-				if( (msg[2].asString).contains("arc"), { /* no arc support yet */ }, { /* grid support only: */
+				serial = msg[1];
+				model = msg[2];
+				portID = msg[3];
 
-					if( portlst.includes(msg[3]) == false, {
-						portlst.add(msg[3]);
-						connectedDevices.add(msg[1]);
-						prefixes.add("/monome");
-						addCallbackComplete.add(false);
-						removeCallbackComplete.add(false);
-						("MonomeGrid device connected to port: "++msg[3]).postln;
-						("MonomeGrid serial: "++msg[1]).postln;
-						("MonomeGrid model: "++msg[2]).postln;
-						portIDX = portlst.detectIndex({arg item, i; item == msg[3]});
-						NetAddr("localhost", msg[3].value).sendMsg("/sys/info", "localhost",NetAddr.localAddr.port);
-						sizeDiscover = OSCdef.newMatching(\sizeDiscovery,
-							{|msg, time, addr, recvPort|
-								columns.add(msg[1]);
-								rows.add(msg[2]);
-								sizeDiscover.free;
-							}, '/sys/size', NetAddr("localhost", msg[3].value)
+				NetAddr("localhost", msg[3].value).sendMsg("/sys/info", "localhost",NetAddr.localAddr.port);
+				sizeDiscover = OSCdef.newMatching(\sizeDiscovery,
+					{|msg, time, addr, recvPort|
+						cl = msg[1];
+						rw = msg[2];
+						if( (cl * rw) > 0, { /* grid support only: */
+							if( portlst.includes(portID) == false, {
+								portlst.add(portID);
+								connectedDevices.add(serial);
+								prefixes.add("/monome");
+								addCallbackComplete.add(false);
+								removeCallbackComplete.add(false);
+								("MonomeGrid device connected to port: "++portID).postln;
+								("MonomeGrid serial: "++serial).postln;
+								("MonomeGrid model: "++model).postln;
+								portIDX = portlst.detectIndex({arg item, i; item == portID});
+								columns.add(cl);
+								rows.add(rw);
+								addCallback.value(serial,portID,prefixes[portIDX]);
+							},{
+								// ("grid already registered!!!").postln;
+							});
+						},{
+							"no monome arc support yet".postln;
+						};
+						seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+						sizeDiscover.free;
 						);
-						addCallback.value(msg[1],msg[3],prefixes[portIDX]);
-					},{
-						// ("grid already registered!!!").postln;
-					});
-				});
-
-				seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+					}, '/sys/size', NetAddr("localhost", msg[3].value)
+				);
 
 		}, '/serialosc/device', seroscnet);
 


### PR DESCRIPTION
improves on https://github.com/monome/monomeSC/commit/5d57842e11ba25a49f8c32f62c2d19cbe54082b2 's string-based device size assumptions by querying `/sys/info` and parsing the returned `/sys/size` messages.

this will also fix cases where neotrellis grids, which do not follow the same naming schemes as monome-made devices, [would fail to connect.](https://llllllll.co/t/grid-studies-supercollider-monomesc-v1-5-library/60948/8)

ty @tehn for the excellent optimization suggestion!