### PR TITLE
v1.8 - arc + general improvements

### DIFF
--- a/Classes/Monome.sc
+++ b/Classes/Monome.sc
@@ -1,0 +1,208 @@
+/*
+v.1.8
+for information about monome devices:
+https://monome.org
+
+for further explanation of serialosc programming:
+https://monome.org/docs/serialosc/osc/
+
+written by:
+raja das, ezra buchla, dani derks
+
+*/
+
+Monome {
+
+	classvar seroscnet, discovery,
+	prefixHandler,
+	add, addCallback, addCallbackComplete,
+	remove, removeCallback, removeCallbackComplete,
+	rows, columns,
+	portlst, prefixes, registeredDevices,
+	quadDirty, ledQuads, redrawTimers;
+
+	var prefixID, rot, fpsVal, isArc; // instance variables
+
+	*initClass {
+
+		addCallback = nil;
+		removeCallback = nil;
+		portlst = List.new(0);
+		registeredDevices = List.new(0);
+		addCallbackComplete = List.new(0);
+		removeCallbackComplete = List.new(0);
+		rows = List.new(0);
+		columns = List.new(0);
+		prefixes = List.new(0);
+		seroscnet = NetAddr.new("localhost", 12002);
+		seroscnet.sendMsg("/serialosc/list", "127.0.0.1", NetAddr.localAddr.port);
+		seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+
+		quadDirty = Dictionary.new;
+		ledQuads = Dictionary.new;
+		redrawTimers = Dictionary.new;
+
+		this.buildOSCResponders;
+
+		ServerQuit.add({
+			seroscnet.disconnect;
+			add.free;
+			discovery.free;
+			remove.free;
+			redrawTimers.do({arg dvc;
+				redrawTimers[dvc].stop;
+			});
+		},\default);
+
+	}
+
+/*	*new { arg rotation, prefix, fps;
+		^ super.new.init(prefix, rotation, fps);
+	}*/
+	*new {
+		^ super.new.init();
+	}
+
+	*buildOSCResponders {
+
+		discovery = OSCdef.newMatching(\monomediscover,
+				{|msg, time, addr, recvPort|
+
+					var portIDX, name, sizeDiscover, rw, cl, portID, serial, model, prefix;
+
+					sizeDiscover = [0,0];
+					serial = msg[1];
+					model = msg[2];
+					portID = msg[3];
+
+					name = msg[2].asString.replace("monome","").replace("40h",64).asInteger;
+
+					sizeDiscover = case
+					{name == 64 } { [8,8] }
+					{name == 128 } { [16,8] }
+					{name == 256 } { [16,16] }
+					{name == 512 } { [32,16] }
+					{msg[2].asString.replace("monome ","") == "one" } { [8,8] }
+					{msg[2].asString.replace("monome ","") == "zero" } { [16,16] }
+					{msg[2].asString.contains("arc") } { [0,0] };
+
+					if( portlst.includes(portID) == false, {
+						portlst.add(portID);
+						registeredDevices.add(serial);
+						prefixes.add(prefix);
+						addCallbackComplete.add(false);
+						removeCallbackComplete.add(false);
+						("Monome device connected to port: "++portID).postln;
+						("Monome device serial: "++serial).postln;
+						("Monome device model: "++model).postln;
+						portIDX = portlst.detectIndex({arg item, i; item == portID});
+						columns.add(sizeDiscover[0]);
+						rows.add(sizeDiscover[1]);
+						addCallback.value(serial,portID,prefixes[portIDX]);
+					},{
+						// ("device already registered!!!").postln;
+					});
+					seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+
+			}, '/serialosc/device', seroscnet);
+
+		add = OSCdef.newMatching(\monomeadd,
+			{|msg, time, addr, recvPort|
+
+				var portIDX, name, sizeDiscover, rw, cl, portID, serial, model, prefix;
+
+				serial = msg[1];
+				model = msg[2];
+				portID = msg[3];
+
+				name = msg[2].asString.replace("monome","").replace("40h",64).asInteger;
+
+				sizeDiscover = case
+				{name == 64 } { [8,8] }
+				{name == 128 } { [16,8] }
+				{name == 256 } { [16,16] }
+				{name == 512 } { [32,16] }
+				{msg[2].asString.replace("monome ","") == "one" } { [8,8] }
+				{msg[2].asString.replace("monome ","") == "zero" } { [16,16] }
+				{msg[2].asString.contains("arc") } { [0,0] };
+
+
+				if( portlst.includes(portID) == false, {
+					columns.add(sizeDiscover[0]);
+					rows.add(sizeDiscover[1]);
+					portlst.add(portID);
+					prefixes.add(prefix);
+					registeredDevices.add(serial);
+					addCallbackComplete.add(false);
+					removeCallbackComplete.add(false);
+				});
+				portIDX = portlst.detectIndex({arg item, i; item == portID});
+				if( addCallbackComplete[portIDX] == false,{
+					("Monome device added to port: "++portID).postln;
+					("Monome device serial: "++serial).postln;
+					("Monome device model: "++model).postln;
+					addCallback.value(serial,portID,prefixes[portIDX]);
+					addCallbackComplete[portIDX] = true;
+					removeCallbackComplete[portIDX] = false;
+				});
+
+				seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+
+		}, '/serialosc/add', seroscnet);
+
+		remove = OSCdef.newMatching(\monomeremove,
+			{|msg, time, addr, recvPort|
+				var portIDX;
+
+				portIDX = portlst.detectIndex({arg item, i; item == msg[3]});
+				if( portIDX.notNil, {
+					if( removeCallbackComplete[portIDX] == false, {
+						removeCallback.value(msg[2],msg[1],msg[3],prefixes[portIDX]);
+						("Monome device removed from port: "++msg[3]).postln;
+						("Monome device serial: "++msg[1]).postln;
+						("Monome device model: "++msg[2]).postln;
+						// we don't want to remove devices from these lists:
+						// registeredDevices.remove(msg[1]);
+						// portlst.remove(msg[3]);
+						addCallbackComplete[portIDX] = false;
+						removeCallbackComplete[portIDX] = true;
+					});
+				});
+
+				seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+
+		}, '/serialosc/remove', seroscnet);
+
+	}
+
+	*refreshConnections {
+		portlst.clear; registeredDevices.clear; prefixes.clear; rows.clear; columns.clear;
+		seroscnet.sendMsg("/serialosc/list", "127.0.0.1", NetAddr.localAddr.port);
+	}
+
+	*getRegisteredDevices {
+		^registeredDevices;
+	}
+
+	*getPortList {
+		^portlst;
+	}
+
+	*getPrefixes {
+		^prefixes;
+	}
+
+	*setAddCallback { arg func;
+		addCallback = nil;
+		addCallback = func;
+	}
+
+	*setRemoveCallback { arg func;
+		removeCallback = nil;
+		removeCallback = func;
+	}
+
+	init {
+	}
+
+}

--- a/Classes/Monome.sc
+++ b/Classes/Monome.sc
@@ -116,13 +116,14 @@ Monome {
 		add = OSCdef.newMatching(\monomeadd,
 			{|msg, time, addr, recvPort|
 
-				var portIDX, name, sizeDiscover, rw, cl, portID, serial, model, prefix;
+				var portIDX, name, sizeDiscover, rw, cl, portID, serial, model, prefix, isArc;
 
 				serial = msg[1];
 				model = msg[2];
 				portID = msg[3];
 
 				name = msg[2].asString.replace("monome","").replace("40h",64).asInteger;
+				isArc = msg[2].asString.contains("arc");
 
 				sizeDiscover = case
 				{name == 64 } { [8,8] }
@@ -140,6 +141,10 @@ Monome {
 					portlst.add(portID);
 					prefixes.add(prefix);
 					registeredDevices.add(serial);
+					if( isArc == true,
+						{ deviceTypes.add("arc") },
+						{ deviceTypes.add("grid") }
+					);
 					addCallbackComplete.add(false);
 					removeCallbackComplete.add(false);
 				});

--- a/Classes/Monome.sc
+++ b/Classes/Monome.sc
@@ -84,7 +84,7 @@ Monome {
 				{name == 128 } { [16,8] }
 				{name == 256 } { [16,16] }
 				{name == 512 } { [32,16] }
-				{msg[2].asString.replace("monome ","") == "one" } { [8,8] }
+				{msg[2].asString.replace("monome ","") == "one" } { [8,16] }
 				{msg[2].asString.replace("monome ","") == "zero" } { [16,16] }
 				{msg[2].asString.contains("arc") } { [0,0] };
 
@@ -130,7 +130,7 @@ Monome {
 				{name == 128 } { [16,8] }
 				{name == 256 } { [16,16] }
 				{name == 512 } { [32,16] }
-				{msg[2].asString.replace("monome ","") == "one" } { [8,8] }
+				{msg[2].asString.replace("monome ","") == "one" } { [8,16] }
 				{msg[2].asString.replace("monome ","") == "zero" } { [16,16] }
 				{msg[2].asString.contains("arc") } { [0,0] };
 

--- a/Classes/Monome.sc
+++ b/Classes/Monome.sc
@@ -57,9 +57,6 @@ Monome {
 
 	}
 
-	/*	*new { arg rotation, prefix, fps;
-	^ super.new.init(prefix, rotation, fps);
-	}*/
 	*new {
 		^ super.new.init();
 	}
@@ -84,7 +81,7 @@ Monome {
 				{name == 128 } { [16,8] }
 				{name == 256 } { [16,16] }
 				{name == 512 } { [32,16] }
-				{msg[2].asString.replace("monome ","") == "one" } { [8,16] }
+				{msg[2].asString.replace("monome ","") == "one" } { [16,8] }
 				{msg[2].asString.replace("monome ","") == "zero" } { [16,16] }
 				{msg[2].asString.contains("arc") } { [0,0] };
 
@@ -130,10 +127,9 @@ Monome {
 				{name == 128 } { [16,8] }
 				{name == 256 } { [16,16] }
 				{name == 512 } { [32,16] }
-				{msg[2].asString.replace("monome ","") == "one" } { [8,16] }
+				{msg[2].asString.replace("monome ","") == "one" } { [16,8] }
 				{msg[2].asString.replace("monome ","") == "zero" } { [16,16] }
 				{msg[2].asString.contains("arc") } { [0,0] };
-
 
 				if( portlst.includes(portID) == false, {
 					columns.add(sizeDiscover[0]);

--- a/Classes/MonomeArc.sc
+++ b/Classes/MonomeArc.sc
@@ -1,0 +1,292 @@
+/*
+v.1.8
+for information about monome devices:
+https://monome.org
+
+for further explanation of serialosc programming:
+https://monome.org/docs/serialosc/osc/
+
+written by:
+joseph rangel, dani derks
+
+*/
+
+MonomeArc : Monome{
+
+	var prefixID, scaleFactor, dvcID, oscout, deltaFunc, keyFunc, deltaFunc;
+
+	*new { arg rotation, prefix;
+		var fps, rotTranslate = [0,90,180,270];
+
+		rotation = case
+		{rotation == nil} {0}
+		{rotation <= 3} {rotTranslate[rotation]}
+		{rotation > 3} {rotation};
+
+		prefix = case
+		{prefix.isNil} {"/monomeArc"}
+		{prefix.notNil} {prefix.asString};
+
+		fps = case
+		{fps.isNil} {60}
+		{fps.notNil} {fps.asFloat};
+
+		^ super.new.initArc(prefix, rotation, fps);
+	}
+
+	initArc { arg prefix_, rot_;
+
+		"initializing arc".postln;
+		prefixID = prefix_;
+		rot = rot_;
+
+		case
+		{ rot == 0 } { scaleFactor = 0 }
+		{ rot == 90 } { scaleFactor = 16 }
+		{ rot == 180 } { scaleFactor = 32 }
+		{ rot == 270 } { scaleFactor = 48 }
+		{ ((rot == 0) or: (rot == 90) or: (rot == 180) or: (rot == 270)).not }
+		{
+			"Did not choose valid rotation. Using default: 0".warn;
+			scaleFactor = 0;
+			rot = 0;
+		};
+
+	}
+
+	connectToPort { arg port;
+		if( portlst.includes(port),{
+			var idx = portlst.detectIndex({arg item, i; item == port});
+			this.connect(idx);
+		},{
+			("no monome arc connected to specified port").warn;
+		});
+	}
+
+	connectToSerial { arg serial;
+		if( registeredDevices.includes(serial.asSymbol),{
+			var idx = registeredDevices.detectIndex({arg item, i; item == serial});
+			this.connect(idx);
+		},{
+			("no monome arc connected with specified serial").warn;
+		});
+	}
+
+	connect { arg devicenum;
+		if( devicenum == nil, {devicenum = 0});
+		if(
+			(portlst[devicenum].value).notNil
+			&& (columns[devicenum].value).notNil,
+			{
+				if(
+					(columns[devicenum] * rows[devicenum] == 0),
+					{
+						var prefixDiscover;
+
+						Monome.buildOSCResponders;
+
+						dvcID = devicenum;
+						oscout = NetAddr.new("localhost", portlst[devicenum].value);
+						Post << "MonomeArc: using device on port #" << portlst[devicenum].value << Char.nl;
+
+						for(0, 3, { arg i; oscout.sendMsg(prefixID++"/ring/all", i, 0);});
+
+						prefixes[devicenum] = prefixID;
+
+						prefixDiscover.free;
+						prefixDiscover = OSCdef.newMatching(\monomeprefix,
+							{|msg, time, addr, recvPort|
+								prefixes[devicenum] = prefixID;
+						}, '/sys/prefix', oscout);
+
+						oscout.sendMsg("/sys/port", NetAddr.localAddr.port);
+						oscout.sendMsg("/sys/prefix", prefixID);
+						oscout.sendMsg("/sys/rotation", rot);
+						oscout.sendMsg("/sys/info");
+
+						addCallbackComplete[dvcID] = false;
+						addCallback.value(registeredDevices[dvcID], portlst[dvcID], prefixes[dvcID]);
+						seroscnet.sendMsg("/serialosc/notify", "127.0.0.1", NetAddr.localAddr.port);
+						isArc = true;
+					},
+					{
+						("!! no monome arc detected at device slot " ++ devicenum).warn;
+					}
+				);
+			},
+			{
+				("no monome arc detected at device slot " ++ devicenum).warn;
+			}
+		);
+	}
+
+	usePort { arg portnum;
+		dvcID = portlst.indexOf(portnum);
+		oscout = NetAddr.new("localhost", portnum);
+		Post << "MonomeArc: using device # " << dvcID << Char.nl;
+
+		oscout.sendMsg("/sys/port", NetAddr.localAddr.port);
+		oscout.sendMsg("/sys/prefix", prefixID);
+		oscout.sendMsg("/sys/rotation", rot);
+	}
+
+	delta { arg func;
+		deltaFunc = OSCdef.newMatching(
+			("deltaFunc_" ++ dvcID).asSymbol,
+			{ arg message, time, addr, recvPort;
+				var n = message[1], d = message[2];
+				if( dvcID.notNil,{
+					if( this.port.value() == addr.port, {
+						func.value(n, d);
+					});
+				});
+			},
+			prefixID++"/enc/delta"
+		);
+	}
+
+	key { arg func;
+		keyFunc = OSCdef.newMatching(
+			("keyFunc_" ++ dvcID).asSymbol,
+			{ arg message, time, addr, recvPort;
+				var n = message[1], s = message[2];
+				if( dvcID.notNil,{
+					if( this.port.value() == addr.port, {
+						func.value(n, s);
+					});
+				});
+			},
+			prefixID++"/enc/key"
+		);
+	}
+
+	ringset { | enc, led, lev |
+
+		oscout.sendMsg(prefixID++"/ring/set", enc,
+			(led + scaleFactor).wrap(0, 63),
+			lev);
+	}
+
+	ringall { | enc, lev |
+		oscout.sendMsg(prefixID++"/ring/all", enc, lev);
+	}
+
+	ringmap	{ | enc, larr |
+
+		scaleFactor.do({
+
+			larr = larr.shift(1, larr @ (larr.size - 1));
+
+		});
+
+		oscout.sendMsg(prefixID++"/ring/map", enc, *larr);
+
+	}
+
+	ringrange { | enc, led1, led2, lev |
+
+		oscout.sendMsg(prefixID++"/ring/range", enc, led1+scaleFactor, led2+scaleFactor, lev);
+	}
+
+	// exercise caution when changing rotation
+	// after change, your led positions may not be desirable.
+	rot_ { arg degree;
+
+		rot = degree;
+
+		case
+		{ rot == 0 } { scaleFactor = 0 }
+		{ rot == 90 } { scaleFactor = 16 }
+		{ rot == 180 } { scaleFactor = 32 }
+		{ rot == 270 } { scaleFactor = 48 }
+		{ (rot != 0) or: (rot != 90) or: (rot != 180) or: (rot != 270) } {
+
+			"Did not choose valid rotation (0, 90, 180, 270). Using default: 0.".warn;
+			scaleFactor = 0;
+			rot = 0;
+		};
+
+		// flash one LED indicating north position
+		for(0, 3, { arg i; this.ringall(i, 0);});
+
+		4.do({
+			for(0, 3, { arg i;
+
+				for(0, 30, { arg brightness;
+
+					this.ringset(i, 0, brightness.fold(0, 15));
+				});
+
+			});
+		});
+
+	}
+
+	port {
+		if( dvcID.notNil, {
+			^portlst[dvcID];
+		},{
+			^nil;
+		});
+	}
+
+	rows {
+		if( dvcID.notNil, {
+			^rows[dvcID];
+		},{
+			^nil;
+		});
+	}
+
+	cols {
+		if( dvcID.notNil, {
+			^columns[dvcID];
+		},{
+			^nil;
+		});
+	}
+
+	serial {
+		if( dvcID.notNil, {
+			^registeredDevices[dvcID];
+		},{
+			^nil;
+		});
+	}
+
+	prefix {
+		if( dvcID.notNil, {
+			^prefixes[dvcID];
+		},{
+			^nil;
+		});
+	}
+
+	rotation {
+		if( dvcID.notNil, {
+			^rot
+		},{
+			^nil;
+		});
+	}
+
+	fps {
+		if( dvcID.notNil, {
+			^fpsVal
+		},{
+			^nil;
+		});
+	}
+
+	dvcnum {
+		^dvcID;
+	}
+
+	cleanup {
+		for(0, 3, { arg i; this.ringall(i, 0);});
+		deltaFunc.free;
+		keyFunc.free;
+		oscout.disconnect;
+	}
+
+}

--- a/Classes/MonomeArc.sc
+++ b/Classes/MonomeArc.sc
@@ -205,6 +205,7 @@ MonomeArc : Monome{
 	setSens { | ring, sensitivity |
 		if( sensitivity == 0, {sensitivity = 1});
 		sens[ring] = sensitivity;
+		tick[ring] = 0;
 	}
 
 	// exercise caution when changing rotation

--- a/Classes/MonomeArc.sc
+++ b/Classes/MonomeArc.sc
@@ -74,7 +74,7 @@ MonomeArc : Monome{
 		);
 		if(
 			(portlst[devicenum].value).notNil
-			&& (columns[devicenum].value).notNil,
+			&& deviceTypes[devicenum] == "arc",
 			{
 				if(
 					(columns[devicenum] * rows[devicenum] == 0),
@@ -316,6 +316,7 @@ MonomeArc : Monome{
 
 	cleanup {
 		for(0, 3, { arg i; this.all(i, 0);});
+		this.refresh;
 		OSCdef(("keyFunc_" ++ dvcID).asSymbol).free;
 		OSCdef(("deltaFunc_" ++ dvcID).asSymbol).free;
 		oscout.disconnect;

--- a/Classes/MonomeArc.sc
+++ b/Classes/MonomeArc.sc
@@ -38,18 +38,13 @@ MonomeArc : Monome{
 		sens = [1,1,1,1];
 		tick = [0,0,0,0];
 
+		if( rot == nil, {scaleFactor = 0; rot = 0} );
+		rot.round(90);
 		case
 		{ rot == 0 } { scaleFactor = 0 }
 		{ rot == 90 } { scaleFactor = 16 }
 		{ rot == 180 } { scaleFactor = 32 }
-		{ rot == 270 } { scaleFactor = 48 }
-		{ ((rot == 0) or: (rot == 90) or: (rot == 180) or: (rot == 270)).not }
-		{
-			"Did not choose valid rotation. Using default: 0".warn;
-			scaleFactor = 0;
-			rot = 0;
-		};
-
+		{ rot == 270 } { scaleFactor = 48 };
 	}
 
 	connectToPort { arg port;
@@ -206,14 +201,14 @@ MonomeArc : Monome{
 		});
 	}
 
-	dark {
+	allOff {
 		for( 0, 3, {
 			arg i;
 			this.all(i,0);
 		});
 	}
 
-	ringmap	{ | ring, larr |
+	ringMap	{ | ring, larr |
 
 		scaleFactor.do({
 
@@ -256,20 +251,6 @@ MonomeArc : Monome{
 			scaleFactor = 0;
 			rot = 0;
 		};
-
-		// flash one LED indicating north position
-		for(0, 3, { arg i; this.all(i, 0);});
-
-		4.do({
-			for(0, 3, { arg i;
-
-				for(0, 30, { arg brightness;
-
-					this.led(i, 0, brightness.fold(0, 15));
-				});
-
-			});
-		});
 
 	}
 

--- a/Classes/MonomeGrid.sc
+++ b/Classes/MonomeGrid.sc
@@ -13,7 +13,7 @@ raja das, ezra buchla, dani derks
 
 MonomeGrid : Monome{
 
-	var prefixID, rot, fpsVal, dvcID, keyFunc, oscout; // instance variables
+	var prefixID, rot, fpsVal, dvcID, keyFunc, oscout, isArc; // instance variables
 
 	*new { arg rotation, prefix, fps;
 		var rotTranslate = [0,90,180,270];
@@ -66,7 +66,7 @@ MonomeGrid : Monome{
 				devicenum = idx;
 			}
 		);
-		if( (portlst[devicenum].value).notNil, {
+		if( (portlst[devicenum].value).notNil && deviceTypes[devicenum] == "grid", {
 
 			var prefixDiscover;
 

--- a/Classes/MonomeGrid.sc
+++ b/Classes/MonomeGrid.sc
@@ -13,7 +13,7 @@ raja das, ezra buchla, dani derks
 
 MonomeGrid : Monome{
 
-	var prefixID, rot, fpsVal, dvcID, keyFunc, oscout, isArc; // instance variables
+	var prefixID, rot, fpsVal, dvcID, keyFunc, oscout; // instance variables
 
 	*new { arg rotation, prefix, fps;
 		var rotTranslate = [0,90,180,270];

--- a/Classes/MonomeGrid.sc
+++ b/Classes/MonomeGrid.sc
@@ -60,7 +60,12 @@ MonomeGrid : Monome{
 	}
 
 	connect { arg devicenum;
-		if( devicenum == nil, {devicenum = 0});
+		if( devicenum == nil && deviceTypes.includesEqual("grid"),
+			{
+				var idx = deviceTypes.detectIndex({arg item, i; item == "grid"});
+				devicenum = idx;
+			}
+		);
 		if( (portlst[devicenum].value).notNil, {
 
 			var prefixDiscover;
@@ -68,6 +73,7 @@ MonomeGrid : Monome{
 			Monome.buildOSCResponders;
 
 			dvcID = devicenum;
+			OSCdef(("keyFunc_" ++ dvcID).asSymbol).free;
 			oscout = NetAddr.new("localhost", portlst[devicenum].value);
 			Post << "MonomeGrid: using device on port #" << portlst[devicenum].value << Char.nl;
 
@@ -278,7 +284,7 @@ MonomeGrid : Monome{
 
 	cleanup {
 		this.all(0);
-		keyFunc.free;
+		OSCdef(("keyFunc_" ++ dvcID).asSymbol).free;
 		oscout.disconnect;
 	}
 }

--- a/HelpSource/Classes/Monome.schelp
+++ b/HelpSource/Classes/Monome.schelp
@@ -1,0 +1,70 @@
+CLASS:: Monome
+summary:: Interface for monome serialosc devices
+categories:: monome
+
+DESCRIPTION::
+Communication and management for monome serialosc controllers. For more information on monome see https://monome.org
+
+For details on the serialosc protocol used with grid devices see https://monome.org/docs/serialosc/serial.txt
+
+All coordinates, identifiers, and level values are 0-indexed.
+
+CLASSMETHODS::
+
+METHOD:: setAddCallback
+assign a callback function whenever a new grid is added / physically connected
+
+ARGUMENT:: func
+
+code::
+(
+Monome.setAddCallback({
+	arg serial, port, prefix;
+	["device was added",serial,port,prefix].postln;
+});
+)
+::
+
+METHOD:: setRemoveCallback
+assign a callback function whenever an added grid is removed / physically disconnected
+
+ARGUMENT:: func
+
+code::
+(
+Monome.setRemoveCallback({
+	arg serial, port, prefix;
+	["device was removed",serial,port,prefix].postln;
+});
+)
+::
+
+METHOD:: getRegisteredDevices
+returns the serial numbers of each device that's been connected since the Server started (or last refreshConnections)
+
+METHOD:: getPortList
+returns the OSC ports of each device that's been connected since the Server started (or last refreshConnections)
+
+METHOD:: getPrefixes
+returns the assigned prefixes of each device that's been connected since the Server started (or last refreshConnections)
+
+METHOD:: refreshConnections
+sends message to serialosc to refresh SuperCollider's list of currently-connected devices
+
+PRIVATE:: new
+
+PRIVATE:: buildOSCResponders
+
+PRIVATE:: portlst
+
+PRIVATE:: prefixes
+
+PRIVATE:: rows
+
+PRIVATE:: columns
+
+PRIVATE:: initClass
+
+INSTANCEMETHODS::
+
+PRIVATE:: init

--- a/HelpSource/Classes/MonomeArc.schelp
+++ b/HelpSource/Classes/MonomeArc.schelp
@@ -69,7 +69,12 @@ function which receives encoder number (0-indexed) and delta (negative: left tur
 code::
 // make sure to clear any running arc code before executing
 (
-// TODO
+~a = MonomeArc.new();
+~a.connect();
+~a.delta({
+	arg n, d;
+	[n,d, "serial: " ++~a.serial,"port: "++~a.port].postln;
+});
 )
 ::
 
@@ -82,7 +87,12 @@ function which receives key (0-indexed) and state (1: down, 0: up)
 code::
 // make sure to clear any running arc code before executing
 (
-// TODO
+~a = MonomeArc.new();
+~a.connect();
+~a.key({
+	arg n, z;
+	[n,z, "serial: " ++~a.serial,"port: "++~a.port].postln;
+});
 )
 ::
 
@@ -101,7 +111,32 @@ brightness level value 0-15
 code::
 // make sure to clear any running arc code before executing
 (
-//TODO
+Server.default = Server.local;
+
+~a = MonomeArc.new();
+
+s.waitForBoot({
+
+	var pos = [0,0,0,0];
+
+	~a.connect();
+
+	// draw notch:
+	for(0, 3, {
+		arg i;
+		~a.led(i, 0, 15);
+	});
+	~a.refresh;
+
+	~a.delta({
+		arg n, d;
+		~a.all(n, 0);
+		pos[n] = (pos[n] + d).wrap(0,63);
+		~a.led(n, pos[n], 15);
+		~a.refresh;
+	});
+});
+
 )
 ::
 
@@ -148,6 +183,39 @@ encoder 0-3
 
 ARGUMENT:: sensitivity
 divisor to scale each encoder tick, default 1 (can be set to negative values for reverse deltas)
+
+code::
+// make sure to clear any running arc code before executing
+(
+Server.default = Server.local;
+
+~a = MonomeArc.new();
+
+s.waitForBoot({
+
+	var pos = [0,0,0,0];
+
+	~a.connect();
+
+	// draw notch + set incrementing sensitivity:
+	for(0, 3, {
+		arg i;
+		~a.setSens(i, i*10);
+		~a.led(i, 0, 15);
+	});
+	~a.refresh;
+
+	~a.delta({
+		arg n, d;
+		~a.all(n, 0);
+		pos[n] = (pos[n] + d).wrap(0,63);
+		~a.led(n, pos[n], 15);
+		~a.refresh;
+	});
+});
+
+)
+::
 
 METHOD:: cleanup
 all leds are turned off and osc communication is disconnected

--- a/HelpSource/Classes/MonomeArc.schelp
+++ b/HelpSource/Classes/MonomeArc.schelp
@@ -22,7 +22,7 @@ cable orientation: left = 0 (default), down = 1, right = 2, up = 3
 ARGUMENT:: prefix
 assign this arc a unique string identifier
 
-defaults to "/monomeArc" if nil
+defaults to "/monome" if nil
 
 PRIVATE:: buildOSCResponders
 
@@ -64,7 +64,7 @@ METHOD:: delta
 assign a function to interpret encoder turns
 
 ARGUMENT:: func
-function which receives encoder number (0-indexed) and delta (-1 or 1)
+function which receives encoder number (0-indexed) and delta (negative: left turn, positive: right turn)
 
 code::
 // make sure to clear any running arc code before executing
@@ -86,15 +86,15 @@ code::
 )
 ::
 
-METHOD:: ringset
+METHOD:: led
 
-ARGUMENT:: enc
+ARGUMENT:: ring
 encoder 0-3
 
 ARGUMENT:: led
-target LED 0-64
+target LED 0-63
 
-ARGUMENT:: lev
+ARGUMENT:: val
 brightness level value 0-15
 
 code::
@@ -104,34 +104,43 @@ code::
 )
 ::
 
-METHOD:: ringall
+METHOD:: all
 set all leds on a specified ring to a variable brightness
 
-ARGUMENT:: enc
+ARGUMENT:: ring
 encoder 0-3
 
-ARGUMENT:: lev
+ARGUMENT:: val
 brightness level value 0-15
 
-METHOD:: ringrange
+METHOD:: segment
 set all leds with a range on a specified ring to a variable brightness
 
-ARGUMENT:: enc
+ARGUMENT:: ring
 encoder 0-3
 
-ARGUMENT:: led1
-start of range, LED value 0-64
+ARGUMENT:: from
+start of range, LED value 0-63
 
-ARGUMENT:: led2
-end of range, LED value 0-64
+ARGUMENT:: to
+end of range, LED value 0-63
 
-ARGUMENT:: lev
+ARGUMENT:: val
 brightness level value 0-15
 
 METHOD:: usePort
 use a specific port for device communication
 
 ARGUMENT:: portnum
+
+METHOD:: setSens
+set the sensitivity divisor for each ring
+
+ARGUMENT:: ring
+encoder 0-3
+
+ARGUMENT:: sensitivity
+divisor to scale each encoder tick, default 1 (can be set to negative values for reverse deltas)
 
 METHOD:: cleanup
 all leds are turned off and osc communication is disconnected
@@ -157,9 +166,13 @@ METHOD:: fps
 RETURNS:: the device's redraw rate (frames per second)
 
 METHOD:: rows
-returns:: number of rows a grid device has (1-indexed)
+returns:: number of rows an arc device has (1-indexed, always 0)
 
 METHOD:: cols
-RETURNS:: number of columns a grid device has (1-indexed)
+RETURNS:: number of columns an arc device has (1-indexed, always 0)
 
 PRIVATE:: initArc
+PRIVATE:: ringmap
+PRIVATE:: setRot
+PRIVATE:: rows
+PRIVATE:: cols

--- a/HelpSource/Classes/MonomeArc.schelp
+++ b/HelpSource/Classes/MonomeArc.schelp
@@ -87,6 +87,7 @@ code::
 ::
 
 METHOD:: led
+set a single LED on a specified ring to a variable brightness (requires link::Classes/MonomeArc#-refresh:: to draw)
 
 ARGUMENT:: ring
 encoder 0-3
@@ -105,7 +106,7 @@ code::
 ::
 
 METHOD:: all
-set all LEDs on a specified ring to a variable brightness
+set all LEDs on a specified ring to a variable brightness (requires link::Classes/MonomeArc#-refresh:: to draw)
 
 ARGUMENT:: ring
 encoder 0-3
@@ -114,7 +115,7 @@ ARGUMENT:: val
 brightness level value 0-15
 
 METHOD:: segment
-set all LEDs with a range on a specified ring to a variable brightness
+set all LEDs with a range on a specified ring to a variable brightness (requires link::Classes/MonomeArc#-refresh:: to draw)
 
 ARGUMENT:: ring
 encoder 0-3
@@ -129,7 +130,10 @@ ARGUMENT:: val
 brightness level value 0-15
 
 METHOD:: dark
-clears all LEDs on all rings
+clears all LEDs on all rings (requires link::Classes/MonomeArc#-refresh:: to draw)
+
+METHOD:: refresh
+writes all queued LED messages
 
 METHOD:: usePort
 use a specific port for device communication

--- a/HelpSource/Classes/MonomeArc.schelp
+++ b/HelpSource/Classes/MonomeArc.schelp
@@ -1,0 +1,165 @@
+CLASS:: MonomeArc
+summary:: Interface for monome arcs
+categories:: monome
+
+DESCRIPTION::
+Communication and management for monome serialosc arc controllers. For more information on monome see https://monome.org
+
+For details on the serialosc protocol used with grid devices see https://monome.org/docs/serialosc/serial.txt
+
+NOTE:: All arc rings and level values are 0-indexed.::
+
+CLASSMETHODS::
+
+METHOD:: new
+allocate MonomeArc object
+
+ARGUMENT:: rotation
+cable orientation: left = 0 (default), down = 1, right = 2, up = 3
+
+(also accepts 0, 90, 180, and 270 degrees)
+
+ARGUMENT:: prefix
+assign this arc a unique string identifier
+
+defaults to "/monomeArc" if nil
+
+PRIVATE:: buildOSCResponders
+
+PRIVATE:: portlst
+
+PRIVATE:: prefixes
+
+PRIVATE:: rows
+
+PRIVATE:: columns
+
+PRIVATE:: initClass
+
+INSTANCEMETHODS::
+
+PRIVATE:: init
+
+METHOD:: connect
+choose which device to connect from the device list
+
+ARGUMENT:: devicenum
+device list index, begins at 0
+
+if not provided, will default to 0
+
+METHOD:: connectToPort
+choose which device to connect via OSC port
+
+ARGUMENT:: port
+OSC port identifier
+
+METHOD:: connectToSerial
+choose which device to connect via serial string
+
+ARGUMENT:: serial
+serial identifier
+
+METHOD:: delta
+assign a function to interpret encoder turns
+
+ARGUMENT:: func
+function which receives encoder number (0-indexed) and delta (-1 or 1)
+
+code::
+// make sure to clear any running arc code before executing
+(
+// TODO
+)
+::
+
+METHOD:: key
+assign a function to interpret key presses
+
+ARGUMENT:: func
+function which receives key x/y coordinates and z state
+
+code::
+// make sure to clear any running arc code before executing
+(
+// TODO
+)
+::
+
+METHOD:: ringset
+
+ARGUMENT:: enc
+encoder 0-3
+
+ARGUMENT:: led
+target LED 0-64
+
+ARGUMENT:: lev
+brightness level value 0-15
+
+code::
+// make sure to clear any running arc code before executing
+(
+//TODO
+)
+::
+
+METHOD:: ringall
+set all leds on a specified ring to a variable brightness
+
+ARGUMENT:: enc
+encoder 0-3
+
+ARGUMENT:: lev
+brightness level value 0-15
+
+METHOD:: ringrange
+set all leds with a range on a specified ring to a variable brightness
+
+ARGUMENT:: enc
+encoder 0-3
+
+ARGUMENT:: led1
+start of range, LED value 0-64
+
+ARGUMENT:: led2
+end of range, LED value 0-64
+
+ARGUMENT:: lev
+brightness level value 0-15
+
+METHOD:: usePort
+use a specific port for device communication
+
+ARGUMENT:: portnum
+
+METHOD:: cleanup
+all leds are turned off and osc communication is disconnected
+
+SUBSECTION::Accessor Methods
+
+METHOD:: prefix
+RETURNS:: device prefix
+
+METHOD:: dvcnum
+RETURNS:: index of device in device list (0-indexed)
+
+METHOD:: serial
+RETURNS:: the device's serial number
+
+METHOD:: port
+RETURNS:: OSC port the device is currently communicating on
+
+METHOD:: rotation
+RETURNS:: rotation of device (cable orientation): 0, 90, 180, 270
+
+METHOD:: fps
+RETURNS:: the device's redraw rate (frames per second)
+
+METHOD:: rows
+returns:: number of rows a grid device has (1-indexed)
+
+METHOD:: cols
+RETURNS:: number of columns a grid device has (1-indexed)
+
+PRIVATE:: initArc

--- a/HelpSource/Classes/MonomeArc.schelp
+++ b/HelpSource/Classes/MonomeArc.schelp
@@ -77,7 +77,7 @@ METHOD:: key
 assign a function to interpret key presses
 
 ARGUMENT:: func
-function which receives key x/y coordinates and z state
+function which receives key (0-indexed) and state (1: down, 0: up)
 
 code::
 // make sure to clear any running arc code before executing
@@ -105,7 +105,7 @@ code::
 ::
 
 METHOD:: all
-set all leds on a specified ring to a variable brightness
+set all LEDs on a specified ring to a variable brightness
 
 ARGUMENT:: ring
 encoder 0-3
@@ -114,7 +114,7 @@ ARGUMENT:: val
 brightness level value 0-15
 
 METHOD:: segment
-set all leds with a range on a specified ring to a variable brightness
+set all LEDs with a range on a specified ring to a variable brightness
 
 ARGUMENT:: ring
 encoder 0-3
@@ -127,6 +127,9 @@ end of range, LED value 0-63
 
 ARGUMENT:: val
 brightness level value 0-15
+
+METHOD:: dark
+clears all LEDs on all rings
 
 METHOD:: usePort
 use a specific port for device communication
@@ -162,15 +165,13 @@ RETURNS:: OSC port the device is currently communicating on
 METHOD:: rotation
 RETURNS:: rotation of device (cable orientation): 0, 90, 180, 270
 
-METHOD:: fps
-RETURNS:: the device's redraw rate (frames per second)
-
 METHOD:: rows
 returns:: number of rows an arc device has (1-indexed, always 0)
 
 METHOD:: cols
 RETURNS:: number of columns an arc device has (1-indexed, always 0)
 
+PRIVATE:: fps
 PRIVATE:: initArc
 PRIVATE:: ringmap
 PRIVATE:: setRot

--- a/HelpSource/Classes/MonomeArc.schelp
+++ b/HelpSource/Classes/MonomeArc.schelp
@@ -245,7 +245,7 @@ RETURNS:: number of columns an arc device has (1-indexed, always 0)
 
 PRIVATE:: fps
 PRIVATE:: initArc
-PRIVATE:: ringmap
+PRIVATE:: ringMap
 PRIVATE:: setRot
 PRIVATE:: rows
 PRIVATE:: cols

--- a/HelpSource/Classes/MonomeArc.schelp
+++ b/HelpSource/Classes/MonomeArc.schelp
@@ -44,9 +44,9 @@ METHOD:: connect
 choose which device to connect from the device list
 
 ARGUMENT:: devicenum
-device list index, begins at 0
+monome device list index, begins at 0 (includes grids and arcs)
 
-if not provided, will default to 0
+if not provided, will default to index of first-connected ar
 
 METHOD:: connectToPort
 choose which device to connect via OSC port
@@ -70,7 +70,7 @@ code::
 // make sure to clear any running arc code before executing
 (
 ~a = MonomeArc.new();
-~a.connect();
+~a.connect(); // no device argument connects to the first-populated arc device
 ~a.delta({
 	arg n, d;
 	[n,d, "serial: " ++~a.serial,"port: "++~a.port].postln;
@@ -88,7 +88,7 @@ code::
 // make sure to clear any running arc code before executing
 (
 ~a = MonomeArc.new();
-~a.connect();
+~a.connect(); // no device argument connects to the first-populated arc device
 ~a.key({
 	arg n, z;
 	[n,z, "serial: " ++~a.serial,"port: "++~a.port].postln;
@@ -119,7 +119,7 @@ s.waitForBoot({
 
 	var pos = [0,0,0,0];
 
-	~a.connect();
+	~a.connect(); // no device argument connects to the first-populated arc device
 
 	// draw notch:
 	for(0, 3, {
@@ -164,9 +164,6 @@ end of range, LED value 0-63
 ARGUMENT:: val
 brightness level value 0-15
 
-METHOD:: dark
-clears all LEDs on all rings (requires link::Classes/MonomeArc#-refresh:: to draw)
-
 METHOD:: refresh
 writes all queued LED messages
 
@@ -195,7 +192,7 @@ s.waitForBoot({
 
 	var pos = [0,0,0,0];
 
-	~a.connect();
+	~a.connect(); // no device argument connects to the first-populated arc device
 
 	// draw notch + set incrementing sensitivity:
 	for(0, 3, {

--- a/HelpSource/Classes/MonomeGrid.schelp
+++ b/HelpSource/Classes/MonomeGrid.schelp
@@ -7,10 +7,7 @@ Communication and management for monome serialosc grid controllers. For more inf
 
 For details on the serialosc protocol used with grid devices see https://monome.org/docs/serialosc/serial.txt
 
-All grid coordinates and level values are 0-indexed.
-
-NOTE:: If a monome grid is connected after Server boot, it will not be detected until MonomeGrid.initClass() or 'Recompile Class Library' is executed.
-::
+NOTE:: All grid coordinates and level values are 0-indexed.::
 
 NOTE:: January 2011 devices only support four intensity levels (off + 3 brightness levels). The value passed in methods prefixed "lev" will be “rounded down” to the lowest available intensity as below:
 
@@ -40,48 +37,6 @@ ARGUMENT:: fps
 rate of maximum grid redraw in frames per second
 
 defaults to 60 if nil
-
-METHOD:: setAddCallback
-assign a callback function whenever a new grid is added / physically connected
-
-ARGUMENT:: func
-
-code::
-// make sure to clear any running grid code before executing
-(
-MonomeGrid.setAddCallback({
-	arg serial, port, prefix;
-	["grid was added",serial,port,prefix].postln;
-});
-)
-::
-
-METHOD:: setRemoveCallback
-assign a callback function whenever an added grid is removed / physically disconnected
-
-ARGUMENT:: func
-
-code::
-// make sure to clear any running grid code before executing
-(
-MonomeGrid.setRemoveCallback({
-	arg serial, port, prefix;
-	["grid was removed",serial,port,prefix].postln;
-});
-)
-::
-
-METHOD:: getConnectedDevices
-returns the serial numbers of each device that's been connected since the Server started (or last refreshConnections)
-
-METHOD:: getPortList
-returns the OSC ports of each device that's been connected since the Server started (or last refreshConnections)
-
-METHOD:: getPrefixes
-returns the assigned prefixes of each device that's been connected since the Server started (or last refreshConnections)
-
-METHOD:: refreshConnections
-sends message to serialosc to refresh SuperCollider's list of currently-connected devices
 
 
 PRIVATE:: buildOSCResponders
@@ -254,3 +209,5 @@ returns:: number of rows a grid device has (1-indexed)
 
 METHOD:: cols
 RETURNS:: number of columns a grid device has (1-indexed)
+
+PRIVATE:: initGrid

--- a/HelpSource/Classes/MonomeGrid.schelp
+++ b/HelpSource/Classes/MonomeGrid.schelp
@@ -59,9 +59,9 @@ METHOD:: connect
 choose which device to connect from the device list
 
 ARGUMENT:: devicenum
-device list index, begins at 0
+monome device list index, begins at 0 (includes grids and arcs)
 
-if not provided, will default to 0
+if not provided, will default to index of first-connected grid
 
 METHOD:: connectToPort
 choose which device to connect via OSC port
@@ -88,7 +88,7 @@ code::
 
 s.waitForBoot({
 
-	~m.connect(0); // explicitly connect to the first-populated device
+	~m.connect(); // no device argument connects to the first-populated grid device
 	~m.key({ arg x,y,z;
 		case
 		{z == 1} {('('++x++','++y++') | key down').postln}
@@ -117,7 +117,7 @@ code::
 
 s.waitForBoot({
 
-	~m.connect(); // no device argument connects to the first-populated device
+	~m.connect(); // no device argument connects to the first-populated grid device
 
 	~m.key({ arg x,y,z;
 		~m.led(x,y,z * 15);
@@ -145,7 +145,7 @@ code::
 
 s.waitForBoot({
 
-	~m.connect(0); // explicitly connect to the first-populated device
+	~m.connect(0); // explicitly connect to the first-populated monome device
 
 	~m.key({ arg x,y,z;
 		~m.ledset(x,y,z);

--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ To install the SuperCollider library for monome grid devices:
 - in SuperCollider, recompile the class library (`Language > Recompile Class Library`)
   - macOS: <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
   - Windows / Linux: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
+
+## study
+
+To learn these libraries, please refer to the SuperCollider studies on monome's website:
+
+- [grid](https://monome.org/docs/grid/studies/sc/)
+- [arc](https://monome.org/docs/arc/studies/sc/)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Communication and management for monome serialosc devices within the open-source
 
 Contains:
 
-- `Monome` class (by Raja Das, Ezra Buchla, and Dani Derks) manages serialosc server relay
-- `MonomeGrid` subclass (Ibid.) connects monome grids (all editions)
-- `MonomeArc` subclass (by Joseph Rangel and Dani Derks) connects monome arcs (all editions)
+- `Monome` class manages serialosc server relay
+- `MonomeGrid` subclass connects monome grids (all editions)
+- `MonomeArc` subclass connects monome arcs (all editions)
+
+Created by Raja Das, Ezra Buchla, Dani Derks, and Joseph Rangel.
 
 ## installation
 
@@ -21,10 +23,3 @@ To install the SuperCollider library for monome grid devices:
 - in SuperCollider, recompile the class library (`Language > Recompile Class Library`)
   - macOS: <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
   - Windows / Linux: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
-
-## study
-
-To learn these libraries, please refer to the SuperCollider studies on monome's website:
-
-- [grid](https://monome.org/docs/grid/studies/sc/)
-- [arc](https://monome.org/docs/arc/studies/sc/)

--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ To install the SuperCollider library for monome grid devices:
 - in SuperCollider, recompile the class library (`Language > Recompile Class Library`)
   - macOS: <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
   - Windows / Linux: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
+
+## study
+
+To learn these libraries, please refer to the SuperCollider studies on monome's website:
+
+- [grid](https://monome.org/docs/grid/studies/sc/)
+- [arc](https://monome.org/docs/arc/studies/sc/)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To install the SuperCollider library for monome grid devices:
 - in SuperCollider, recompile the class library (`Language > Recompile Class Library`)
   - macOS: <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
   - Windows / Linux: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
-
+  
 ## study
 
 To learn these libraries, please refer to the SuperCollider studies on monome's website:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 Communication and management for monome serialosc devices within the open-source audio synthesis platform SuperCollider.
 
-`MonomeGrid` class by Raja, Ezra Buchla, and Dan Derks.
+Contains:
+
+- `Monome` class (by Raja Das, Ezra Buchla, and Dani Derks) manages serialosc server relay
+- `MonomeGrid` subclass (Ibid.) connects monome grids (all editions)
+- `MonomeArc` subclass (by Joseph Rangel and Dani Derks) connects monome arcs (all editions)
 
 ## installation
 


### PR DESCRIPTION
the headline on this update is arc compatibility, but this required some other small adjustments which feel like they nicely round the library out:

## new
- functionality now split across one main `Monome` class and two subclasses (`MonomeGrid` and `MonomeArc`)
- `Monome` class handles serialosc communication and device meta-management
- `MonomeGrid` subclass handles connectivity to connected monome grid devices, and should be a direct drop-in replacement for any previous monomeSC sketches
- `MonomeArc` subclass handles connectivity to connected arcs
  - this subclass includes a helper for setting per-encoder sensitivity (`.setSens`)
  - rather than draw LEDs with a Routine (like `MonomeGrid`), the arc subclass employs a `.refresh` method to draw queued LED messages -- this keeps consistent with norns and `iii` scripting practices

## fixed
- device detection is now much clearer + easier to manage
- key and delta callbacks get cleared on `cleanup`
- help files and examples updated